### PR TITLE
サイドバーに新着メッセージを表示

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,15 @@
 class Group < ApplicationRecord
   has_many :group_users
-  has_many :users, through: :group_users
-  validates :name, presence: true, uniqueness: true
-  
   has_many :messages
+  has_many :users, through: :group_users
+
+  validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end  
 end

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -16,4 +16,4 @@
           .group__name
             = group.name
           .group__message
-            新着メッセージ
+            = group.show_last_message


### PR DESCRIPTION
# What
サイドバーのグループ部分に新着メッセージを表示するビューを実装。

# Why
新しくメッセージが投稿された際に、グループ画面を開かなくても新着メッセージが投稿されたことが確認できるようにするため。