### PR TITLE
グループ編集後のリダイレクト先を変更

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,18 +6,16 @@
     .header
       .left-header
         .left-header__title
-          グループ名
+          = @group.name
         %ul.left-header__members
           Member：
           %li.member
-            メンバー名
-          %li.member
-            メンバー名
-          %li.member
-            メンバー名
+            - @group.users.each do |user|
+              = user.name
       .right-header
         .right-header__button
-          Edit
+          = link_to edit_group_path(@group.id) do
+            Edit
     .messages
       = render @messages
     .form


### PR DESCRIPTION
# What
グループを編集後に今いるグループのメッセージ一覧が表示されるようにリダイレクト先を変更。

# Why
グループ編集後毎回ルートパスのページへ移行してしまい、再度グループのメッセージ一覧画面へ移行する必要があるので、編集後そのままグループのメッセージ一覧画面へ移行するよう実装した。